### PR TITLE
group requirements, manage it in pyproject only

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,20 +12,29 @@ dynamic = ["version", "description"]
 dependencies = [
     "requests >=2.26.0",
     "python-dotenv >=0.19.0",
-    "boto3 >=1.18.36",
-    "pyperclip >=1.8.2",
 ]
 
 [tool.flit.module]
 name = "pybites_tools"
 
 [project.optional-dependencies]
+aws = [
+    "boto3 >=1.18.36",
+]
+pybites = [
+    "pybites-alarm",
+    "pybites-carbon",
+    "pybites-pysource",
+]
 test = [
     "pytest",
     "pytest-cov",
     "mypy",
     "flake8",
     "pre-commit",
+]
+zen = [
+    "pyperclip >=1.8.2",
 ]
 
 [project.urls]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,4 +1,0 @@
-requests==2.26.0
-python-dotenv==0.19.0
-boto3==1.18.36
-pyperclip==1.8.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,0 @@
--r base.txt
-pytest
-pytest-cov
-mypy
-flake8
-pre-commit


### PR DESCRIPTION
see https://flit.readthedocs.io/_/downloads/en/latest/pdf/ - page 9

this works now:

pip install . -> installs base (common) requirements
pip install ".[aws]" -> installs aws requirements
pip install ".[zen]" -> installs zen requirements