### PR TITLE
add missing pytz dependency in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "python-dotenv >=0.19.0",
     "boto3 >=1.18.36",
     "pyperclip >=1.8.2",
+    "pytz >=2021.3",
 ]
 
 [tool.flit.module]


### PR DESCRIPTION
As the PyPi version is outdated in comparison to the code I tried installing from the Git repo directly which works. But pytz module is missing in pyproject.toml:

```
(tool-test) ➜  tool-test python -m pybites_tools.worldclock
Traceback (most recent call last):
  File "/Users/axel/.pyenv/versions/3.9.10/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/axel/.pyenv/versions/3.9.10/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/axel/git/tool-test/.venv/lib/python3.9/site-packages/pybites_tools/worldclock.py", line 7, in <module>
    import pytz
ModuleNotFoundError: No module named 'pytz'
```

This PR fixes this issue.