### PR TITLE
add worldclock support for dates:

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,14 +104,15 @@ $ python -m pybites_tools.aws -f file-path (-b bucket) (-a acl)
 
 ### WorldClock from the command line
 
-Add the timezones that you would like displayed to the TIMEZONE_LIST configuration variable in `.env`. (List of all timezones [here](https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568).)
-And uncomment/set the TIME_FORMAT in case you want a different output format (see [strftime() and strptime() Format Codes](https://docs.python.org/3.10/library/datetime.html#strftime-and-strptime-format-codes) for options).
+Add the timezones that you would like displayed to the TIMEZONE_LIST configuration variable in `.env`. (List of all timezones [here](https://gist.github.com/heyalexej/8bf688fd67d7199be4a1682b3eec7568)). And uncomment/set the TIME_FORMAT in case you want a different output format (see [strftime() and strptime() Format Codes](https://docs.python.org/3.10/library/datetime.html#strftime-and-strptime-format-codes) for options).
+When working with others in multiple timezones you usually refer to your local timezone for reference. That said you can uncomment/set the TIMEZONE to your local one to avoid using the `-tz` command line parameter every time (if omitted UTC is used).
 
 Like this:
 
 ```
 TIMEZONE_LIST=["America/Los_Angeles","CET","Australia/Sydney"]
 TIME_FORMAT="%H:%M %z" # 24-hour clock with UTC offset
+TIMEZONE="Europe/Berlin"
 ```
 
 Then:
@@ -131,6 +132,19 @@ $ python -m pybites_tools.worldclock -hr 22 -min 55 -tz Europe/London
 America/Los_Angeles       02:55PM
 CET                       11:55PM
 Australia/Sydney          08:55AM
+```
+
+Around the dates where daylight saving times (DST) are changed finding the right timeslot for a meeting/call in the next week can be off due to the DST changed. That's why you can use the `--year`, `--month` and `--day` to find the correct time.
+
+```
+$ python -m pybites_tools.worldclock -hr 15 -min 0 -y 2022 -m 3 -d 10
+America/Los_Angeles       07:00AM
+CET                       04:00PM
+Australia/Sydney          02:00AM
+$ python -m pybites_tools.worldclock -hr 15 -min 0 -y 2022 -m 3 -d 15
+America/Los_Angeles       08:00AM
+CET                       04:00PM
+Australia/Sydney          02:00AM
 ```
 
 ### Copy Zen of Python to clipboard

--- a/pybites_tools/worldclock.py
+++ b/pybites_tools/worldclock.py
@@ -12,7 +12,7 @@ DEFAULT_TIMEZONE = "UTC"
 HOURS_IN_DAY = range(0, 24)
 MINUTES_IN_HOUR = range(0, 60)
 MONTHS_IN_YEAR = range(1, 13)
-DAYS_IN_MONTH = range(1, 32)
+MAX_DAYS_IN_MONTH = range(1, 32)
 
 load_dotenv()
 
@@ -37,8 +37,7 @@ def convert_time(
         )
 
     for zone in timezones:
-        # gettz returns None if not a valid timezone
-        if not tz.gettz(zone):
+        if not tz.gettz(zone) is not None:
             raise WorldClockException(
                 "UnknownTimeZoneError - Check that your timezones are spelled correctly."
             )
@@ -46,7 +45,7 @@ def convert_time(
             hour in HOURS_IN_DAY
             and minute in MINUTES_IN_HOUR
             and month in MONTHS_IN_YEAR
-            and day in DAYS_IN_MONTH
+            and day in MAX_DAYS_IN_MONTH
         ):
             user_given_tz_now = datetime.now(tz.gettz(tzone))
             user_given_time = user_given_tz_now.replace(

--- a/pybites_tools/worldclock.py
+++ b/pybites_tools/worldclock.py
@@ -4,14 +4,15 @@ import os
 from datetime import datetime
 import sys
 
-import pytz
 from dotenv import load_dotenv
-from pytz import timezone
+from dateutil import tz
 
 DEFAULT_FMT = "%I:%M%p"
 DEFAULT_TIMEZONE = "UTC"
 HOURS_IN_DAY = range(0, 24)
 MINUTES_IN_HOUR = range(0, 60)
+MONTHS_IN_YEAR = range(1, 13)
+DAYS_IN_MONTH = range(1, 32)
 
 load_dotenv()
 
@@ -20,7 +21,14 @@ class WorldClockException(Exception):
     pass
 
 
-def convert_time(hour: int = None, minute: int = None, tzone: str = None) -> None:
+def convert_time(
+    hour: int = None,
+    minute: int = None,
+    year: int = None,
+    month: int = None,
+    day: int = None,
+    tzone: str = None,
+) -> None:
     try:
         timezones = json.loads(os.environ["TIMEZONE_LIST"])
     except json.decoder.JSONDecodeError:
@@ -29,18 +37,25 @@ def convert_time(hour: int = None, minute: int = None, tzone: str = None) -> Non
         )
 
     for zone in timezones:
-        try:
-            if hour in HOURS_IN_DAY and minute in MINUTES_IN_HOUR:
-                user_given_tz_now = datetime.now(timezone(f"{tzone}"))
-                user_given_time = user_given_tz_now.replace(hour=hour, minute=minute)
-                user_given_time_utc = user_given_time.astimezone(pytz.utc)
-                converted_time = user_given_time_utc.astimezone(pytz.timezone(zone))
-            else:
-                converted_time = datetime.now(pytz.timezone(zone))
-        except pytz.exceptions.UnknownTimeZoneError:
+        # gettz returns None if not a valid timezone
+        if not tz.gettz(zone):
             raise WorldClockException(
                 "UnknownTimeZoneError - Check that your timezones are spelled correctly."
             )
+        if (
+            hour in HOURS_IN_DAY
+            and minute in MINUTES_IN_HOUR
+            and month in MONTHS_IN_YEAR
+            and day in DAYS_IN_MONTH
+        ):
+            user_given_tz_now = datetime.now(tz.gettz(tzone))
+            user_given_time = user_given_tz_now.replace(
+                hour=hour, minute=minute, year=year, month=month, day=day
+            )
+            user_given_time_utc = user_given_time.astimezone(tz.UTC)
+            converted_time = user_given_time_utc.astimezone(tz.gettz(zone))
+        else:
+            converted_time = datetime.now(tz.gettz(zone))
 
         FMT = os.getenv("TIME_FORMAT", DEFAULT_FMT)
         formatted_time = converted_time.strftime(FMT)
@@ -50,14 +65,22 @@ def convert_time(hour: int = None, minute: int = None, tzone: str = None) -> Non
 def main():
     now = datetime.now()
 
+    # override DEFAULT_TIMEZONE if TIMEZONE is present in .env
+    timezone = os.getenv("TIMEZONE", DEFAULT_TIMEZONE)
+
     parser = argparse.ArgumentParser()
     parser.add_argument("-hr", "--hour", type=int, default=now.hour)
     parser.add_argument("-min", "--minute", type=int, default=now.minute)
-    parser.add_argument("-tz", "--tzone", type=str, default=DEFAULT_TIMEZONE)
+    parser.add_argument("-y", "--year", type=int, default=now.year)
+    parser.add_argument("-m", "--month", type=int, default=now.month)
+    parser.add_argument("-d", "--day", type=int, default=now.day)
+    parser.add_argument("-tz", "--tzone", type=str, default=timezone)
 
     args = parser.parse_args()
     try:
-        convert_time(args.hour, args.minute, args.tzone)
+        convert_time(
+            args.hour, args.minute, args.year, args.month, args.day, args.tzone
+        )
     except WorldClockException as exc:
         print(exc)
         sys.exit(1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "python-dotenv >=0.19.0",
     "boto3 >=1.18.36",
     "pyperclip >=1.8.2",
-    "pytz >=2021.3",
+    "python-dateutil >=2.8.2",
 ]
 
 [tool.flit.module]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,4 +2,4 @@ requests==2.26.0
 python-dotenv==0.19.0
 boto3==1.18.36
 pyperclip==1.8.2
-pytz==2021.3
+python-dateutil==2.8.2

--- a/tests/test_worldclock.py
+++ b/tests/test_worldclock.py
@@ -14,7 +14,7 @@ from pybites_tools.worldclock import WorldClockException
         (
             [],
             (
-                "CET                       03:30PM\n"
+                "Europe/Berlin             03:30PM\n"
                 "Australia/Sydney          12:30AM\n"
                 "America/Los_Angeles       06:30AM\n"
             ),
@@ -22,7 +22,7 @@ from pybites_tools.worldclock import WorldClockException
         (
             [22, 55, 2022, 4, 1, "Europe/London"],
             (
-                "CET                       11:55PM\n"
+                "Europe/Berlin             11:55PM\n"
                 "Australia/Sydney          08:55AM\n"
                 "America/Los_Angeles       02:55PM\n"
             ),
@@ -30,15 +30,25 @@ from pybites_tools.worldclock import WorldClockException
         (
             [0, 1, 2022, 4, 1, "UTC"],
             (
-                "CET                       02:01AM\n"
+                "Europe/Berlin             02:01AM\n"
                 "Australia/Sydney          11:01AM\n"
                 "America/Los_Angeles       05:01PM\n"
+            ),
+        ),
+        (
+            [0, 1, 2022, 3, 1, "UTC"],
+            (
+                "Europe/Berlin             01:01AM\n"
+                "Australia/Sydney          11:01AM\n"
+                "America/Los_Angeles       04:01PM\n"
             ),
         ),
     ],
 )
 def test_worldclock(monkeypatch, capsys, args, expected):
-    mock_env = {"TIMEZONE_LIST": '["CET", "Australia/Sydney", "America/Los_Angeles"]'}
+    mock_env = {
+        "TIMEZONE_LIST": '["Europe/Berlin", "Australia/Sydney", "America/Los_Angeles"]'
+    }
     monkeypatch.setattr(os, "environ", mock_env)
     worldclock.convert_time(*args)
     captured = capsys.readouterr()

--- a/tests/test_worldclock.py
+++ b/tests/test_worldclock.py
@@ -20,7 +20,7 @@ from pybites_tools.worldclock import WorldClockException
             ),
         ),
         (
-            [22, 55, "Europe/London"],
+            [22, 55, 2022, 4, 1, "Europe/London"],
             (
                 "CET                       11:55PM\n"
                 "Australia/Sydney          08:55AM\n"
@@ -28,7 +28,7 @@ from pybites_tools.worldclock import WorldClockException
             ),
         ),
         (
-            [0, 1, "UTC"],
+            [0, 1, 2022, 4, 1, "UTC"],
             (
                 "CET                       02:01AM\n"
                 "Australia/Sydney          11:01AM\n"


### PR DESCRIPTION
* allow cmdline args for dates to circumvent DST issues
* set reference TIMEZONE env var -> fallback to UTC
* switch pytz to dateutil.tz due to https://blog.ganssle.io/tag/timezones.html
* adapt tests for new args -> passing
* update README