### PR TITLE
Added a date_offset argument to WorldClock

### DIFF
--- a/pybites_tools/worldclock.py
+++ b/pybites_tools/worldclock.py
@@ -83,7 +83,6 @@ def main():
 
     args = parser.parse_args()
     try:
-        print(f"args: {args}")
         convert_time(
             args.hour,
             args.minute,

--- a/pybites_tools/worldclock.py
+++ b/pybites_tools/worldclock.py
@@ -1,11 +1,11 @@
 import argparse
 import json
 import os
-from datetime import datetime
 import sys
+from datetime import datetime
 
-from dotenv import load_dotenv
 from dateutil import tz
+from dotenv import load_dotenv
 
 DEFAULT_FMT = "%I:%M%p"
 DEFAULT_TIMEZONE = "UTC"
@@ -28,6 +28,7 @@ def convert_time(
     month: int = None,
     day: int = None,
     tzone: str = None,
+    date_offset: bool = False,
 ) -> None:
     try:
         timezones = json.loads(os.environ["TIMEZONE_LIST"])
@@ -58,6 +59,10 @@ def convert_time(
 
         FMT = os.getenv("TIME_FORMAT", DEFAULT_FMT)
         formatted_time = converted_time.strftime(FMT)
+
+        if date_offset:
+            formatted_time += f"   {converted_time.strftime('%d %b %Y')}"
+
         print(f"{zone:25} {formatted_time}")
 
 
@@ -74,11 +79,19 @@ def main():
     parser.add_argument("-m", "--month", type=int, default=now.month)
     parser.add_argument("-d", "--day", type=int, default=now.day)
     parser.add_argument("-tz", "--tzone", type=str, default=timezone)
+    parser.add_argument("-do", "--date-offset", action="store_true")
 
     args = parser.parse_args()
     try:
+        print(f"args: {args}")
         convert_time(
-            args.hour, args.minute, args.year, args.month, args.day, args.tzone
+            args.hour,
+            args.minute,
+            args.year,
+            args.month,
+            args.day,
+            args.tzone,
+            args.date_offset,
         )
     except WorldClockException as exc:
         print(exc)

--- a/tests/test_worldclock.py
+++ b/tests/test_worldclock.py
@@ -67,3 +67,67 @@ def test_bad_timezone_entered(monkeypatch, capsys):
     monkeypatch.setattr(os, "environ", mock_env)
     with pytest.raises(WorldClockException, match="UnknownTimeZoneError.*correctly"):
         worldclock.convert_time()
+
+
+@freeze_time("2021-10-17 13:30:00")
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        (
+            [],
+            (
+                "Europe/Berlin             03:30PM\n"
+                "Australia/Sydney          12:30AM\n"
+                "America/Los_Angeles       06:30AM\n"
+            ),
+        ),
+        (
+            [None, None, None, None, None, None, True],
+            (
+                "Europe/Berlin             03:30PM   17 Oct 2021\n"
+                "Australia/Sydney          12:30AM   18 Oct 2021\n"
+                "America/Los_Angeles       06:30AM   17 Oct 2021\n"
+            ),
+        ),
+        (
+            [22, 55, 2022, 4, 1, "Europe/London", True],
+            (
+                "Europe/Berlin             11:55PM   01 Apr 2022\n"
+                "Australia/Sydney          08:55AM   02 Apr 2022\n"
+                "America/Los_Angeles       02:55PM   01 Apr 2022\n"
+            ),
+        ),
+        (
+            [0, 1, 2022, 4, 1, "UTC", True],
+            (
+                "Europe/Berlin             02:01AM   01 Apr 2022\n"
+                "Australia/Sydney          11:01AM   01 Apr 2022\n"
+                "America/Los_Angeles       05:01PM   31 Mar 2022\n"
+            ),
+        ),
+        (
+            [0, 1, 2022, 3, 1, "UTC", True],
+            (
+                "Europe/Berlin             01:01AM   01 Mar 2022\n"
+                "Australia/Sydney          11:01AM   01 Mar 2022\n"
+                "America/Los_Angeles       04:01PM   28 Feb 2022\n"
+            ),
+        ),
+        (
+            [20, 50, 2022, 12, 31, "UTC", True],
+            (
+                "Europe/Berlin             09:50PM   31 Dec 2022\n"
+                "Australia/Sydney          07:50AM   01 Jan 2023\n"
+                "America/Los_Angeles       12:50PM   31 Dec 2022\n"
+            ),
+        ),
+    ],
+)
+def test_worldclock_with_date_offset(monkeypatch, capsys, args, expected):
+    mock_env = {
+        "TIMEZONE_LIST": '["Europe/Berlin", "Australia/Sydney", "America/Los_Angeles"]'
+    }
+    monkeypatch.setattr(os, "environ", mock_env)
+    worldclock.convert_time(*args)
+    captured = capsys.readouterr()
+    assert captured.out == expected


### PR DESCRIPTION
I have added --date-offset argument to worldclock.py

This allows the user to print out the date for their converted times. This allows a clearer output when converting times between, for example, converting from UTC to Australia and Los Angeles.